### PR TITLE
Adds quickstarts to ODF operator

### DIFF
--- a/controllers/quickstart_constants.go
+++ b/controllers/quickstart_constants.go
@@ -1,0 +1,186 @@
+package controllers
+
+import "strings"
+
+var AllQuickStarts = [][]byte{[]byte(gettingStartedQS), []byte(odfConfigAndManagementQS)}
+
+var gettingStartedQS = strings.ReplaceAll(`
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: "getting-started-odf"
+spec:
+  displayName: Getting started with OpenShift Data Foundation
+  durationMinutes: 10
+  icon: data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHdpZHRoPSIxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTY2LjcgNTUuOGM2LjYgMCAxNi4xLTEuNCAxNi4xLTkuMiAwLS42IDAtMS4yLS4yLTEuOGwtMy45LTE3Yy0uOS0zLjctMS43LTUuNC04LjMtOC43LTUuMS0yLjYtMTYuMi02LjktMTkuNS02LjktMy4xIDAtNCA0LTcuNiA0LTMuNSAwLTYuMS0yLjktOS40LTIuOS0zLjIgMC01LjIgMi4xLTYuOCA2LjYgMCAwLTQuNCAxMi41LTUgMTQuMy0uMS4zLS4xLjctLjEgMSAuMSA0LjcgMTkuMiAyMC42IDQ0LjcgMjAuNm0xNy4xLTZjLjkgNC4zLjkgNC44LjkgNS4zIDAgNy40LTguMyAxMS40LTE5LjEgMTEuNC0yNC42IDAtNDYuMS0xNC40LTQ2LjEtMjMuOSAwLTEuMy4zLTIuNi44LTMuOS04LjkuNS0yMC4zIDIuMS0yMC4zIDEyLjIgMCAxNi41IDM5LjIgMzYuOSA3MC4yIDM2LjkgMjMuOCAwIDI5LjgtMTAuNyAyOS44LTE5LjIgMC02LjctNS44LTE0LjMtMTYuMi0xOC44IiBmaWxsPSIjZWQxYzI0Ii8+PHBhdGggZD0ibTgzLjggNDkuOGMuOSA0LjMuOSA0LjguOSA1LjMgMCA3LjQtOC4zIDExLjQtMTkuMSAxMS40LTI0LjYgMC00Ni4xLTE0LjQtNDYuMS0yMy45IDAtMS4zLjMtMi42LjgtMy45bDEuOS00LjhjLS4xLjMtLjEuNy0uMSAxIDAgNC44IDE5LjEgMjAuNyA0NC43IDIwLjcgNi42IDAgMTYuMS0xLjQgMTYuMS05LjIgMC0uNiAwLTEuMi0uMi0xLjh6IiBmaWxsPSIjMDEwMTAxIi8+PC9zdmc+
+  description: Learn how to create persistent files, object storage and connect it with your applications.
+  introduction: >-
+    RedHat OpenShift Data Foundation provides a highly integrated collection of cloud storage and data services for OpenShift Container Platform.  
+   
+    In this tour, you'll learn how to add block, file, or object storage to your applications, and how to monitor your storage resources in the OpenShift Data Foundation dashboards.  
+
+      1. Connecting applications to block or file storage (persistent volumes)  
+
+      1. Connecting applications to object storage (object buckets)  
+
+      1. Using the dashboards to monitor OpenShift Data Foundation resources
+
+  tasks:
+    -
+      title: Connecting applications to block or file storage (persistent volumes)
+      description: >-
+
+        If you want yours data to live longer than yours pods, you need persistent volumes.  
+      
+        Persistent volumes exist outside the pod lifecycle, meaning that your data is retained even after your pod has been restarted, rescheduled, or deleted. You might use persistent volumes with a MySQL or WordPress application to store information for longer than the lifetime of any individual application pod.  
+
+
+        After an administrator has set up an OpenShift Data Foundation cluster, developers can use persistent volume claims (PVCs) to request persistent volume (PV) resources without needing to know anything specific about the underlying storage infrastructure.
+
+
+        **Connect your application with a PVC**
+ 
+           1. Click Workloads > Deployments in the navigation menu on the left.  
+   
+           2. Select your project from the Project drop-down and find your application in the list of deployments.  
+   
+           3. Click the Action menu &*⋮&* > Add Storage  
+   
+           4. Select &*Create new claim&*, You would select &*Use existing claim&* here if you wanted to restore an existing persistent volume to a redeployed application.  
+
+           5. Select the appropriate type of storage for your application.
+    
+              - &*For block storage&*, select ocs-storagecluster-ceph-rbd.  
+
+              - &*For file storage&*, select ocs-storagecluster-cephfs.
+
+
+           6. Specify details of the storage you want to create.
+
+           7. Click Save.
+      review:
+        instructions: >-
+          To verify that your application is using persistent volume claim:  
+
+            - Click the name of the deployment that you assigned storage to.  
+
+            - On the deployment details page, look at Type in the Volumes section to verify the type of the PVC you attached.  
+
+            - Click the PVC name and verify the storage class name in the PersistentVolumeClaim Overview page.  
+
+        failedTaskHelp: Try the steps again.
+    -
+      title: Connecting application to Object Storage
+      description: >-
+ 
+        Object Buckets provide an easy way to consume object storage across OpenShift Data Foundation. Use your object service endpoint, access key, and secret key to add your object service provider to OpenShift Data Foundation as a backing store. See Adding storage resources for hybrid or multicloud docs.  
+
+        After your object service is configured, you can create an Object Bucket Claim and connect it to your application.
+
+          1. Click Storage > Object Bucket Claims.  
+
+          2. Click Create Object Bucket Claim.  
+
+          3. Specify a name for your claim and select an appropriate storage class for your application:   
+
+             - &*To use on-premises object storage&* select ocs-storagecluster-ceph-rgw.  
+
+             - &*To use Multicloud Object Gateway&* select openshift-storage.noobaa.io.  
+
+          4. Click Create.
+
+          5. Click the Action menu &*⋮&* > Attach to deployment.
+
+          6. Select the application to attach the Object Bucket Claim to and click Attach.
+
+      review:
+        instructions: >- 
+          To verify that your application is using an object bucket claim:
+
+            - Click the name of the deployment that you assigned storage to.
+
+            - On the deployment click on Environment tab and check if a the new secret and config map were added.
+ 
+        failedTaskHelp: Try the steps again.
+    -
+      title: Using the dashboards to monitor OpenShift Data Foundation resources
+      description:  >-
+        You can monitor any storage resource manage by Openshift Container Storage on Openshift Data Foundation views:
+
+
+        Click Storage > Openshift Data Foundation
+        
+        1. The ODF overview gives you a high level view for all storage systems.
+        
+        1. To get deeper view for a specific system, you can drill down to see system overview.  
+        
+            - The Block & File dashboard tab shows the state of the Openshift Container Storage as whole, as well a the state of the persistent volumes.
+            
+            - The Object dashboard shows the state of the Multicloud Object Gateway, RADOS Object Gateway, and any object claims.
+            
+  conclusion: You finished the Getting Started Quickstart
+`, "&*", "`")
+
+const odfConfigAndManagementQS = `
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: odf-configuration
+spec:
+  displayName: OpenShift Data Foundation Configuration & Management
+  durationMinutes: 5
+  icon: data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHdpZHRoPSIxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTY2LjcgNTUuOGM2LjYgMCAxNi4xLTEuNCAxNi4xLTkuMiAwLS42IDAtMS4yLS4yLTEuOGwtMy45LTE3Yy0uOS0zLjctMS43LTUuNC04LjMtOC43LTUuMS0yLjYtMTYuMi02LjktMTkuNS02LjktMy4xIDAtNCA0LTcuNiA0LTMuNSAwLTYuMS0yLjktOS40LTIuOS0zLjIgMC01LjIgMi4xLTYuOCA2LjYgMCAwLTQuNCAxMi41LTUgMTQuMy0uMS4zLS4xLjctLjEgMSAuMSA0LjcgMTkuMiAyMC42IDQ0LjcgMjAuNm0xNy4xLTZjLjkgNC4zLjkgNC44LjkgNS4zIDAgNy40LTguMyAxMS40LTE5LjEgMTEuNC0yNC42IDAtNDYuMS0xNC40LTQ2LjEtMjMuOSAwLTEuMy4zLTIuNi44LTMuOS04LjkuNS0yMC4zIDIuMS0yMC4zIDEyLjIgMCAxNi41IDM5LjIgMzYuOSA3MC4yIDM2LjkgMjMuOCAwIDI5LjgtMTAuNyAyOS44LTE5LjIgMC02LjctNS44LTE0LjMtMTYuMi0xOC44IiBmaWxsPSIjZWQxYzI0Ii8+PHBhdGggZD0ibTgzLjggNDkuOGMuOSA0LjMuOSA0LjguOSA1LjMgMCA3LjQtOC4zIDExLjQtMTkuMSAxMS40LTI0LjYgMC00Ni4xLTE0LjQtNDYuMS0yMy45IDAtMS4zLjMtMi42LjgtMy45bDEuOS00LjhjLS4xLjMtLjEuNy0uMSAxIDAgNC44IDE5LjEgMjAuNyA0NC43IDIwLjcgNi42IDAgMTYuMS0xLjQgMTYuMS05LjIgMC0uNiAwLTEuMi0uMi0xLjh6IiBmaWxsPSIjMDEwMTAxIi8+PC9zdmc+
+  description: Learn how to configure OpenShift Data Foundation to meet your deployment
+    needs.
+  prerequisites: ["Getting Started with OpenShift Data Foundation", "Install the Openshift Data Foundation" ]
+  introduction: In this tour, you will learn about the various configurations available
+    to customize your OpenShift® Data Foundation deployment.
+  tasks:
+    - title: Expand the ODF Storage System
+      description: |-
+        When we install the ODF operator we created a storage cluster, chose
+        the cluster size, provisioned the underlying storage subsystem, deployed necessary
+        drivers, and created the storage classes to allow the OpenShift users to easily
+        provision and consume storage services that have just been deployed
+       
+        When the capacity of the cluster is about to runout we will notify you.
+       
+        **To expand the OCS storage cluster follow these steps:**
+        1. Go to installed operators page and click on **OpenShift Data Foundation**
+        2. Go to storage cluster tab
+        3. Click on the **3 dots icon**
+        4. Click on add capacity
+        5. Use the expand cluster modal if your capacity is about to runout.
+      review:
+        instructions: |-
+          ####  To verify that you have expanded your storage cluster.
+          Did you expand your cluster?
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You have expanded the Storage Cluster for the ODF operator!
+        failed: Try the steps again.
+    - title: Bucket Class Configuration
+      description: |-
+
+          Bucket class policy determines the bucket's data location. Its set of policies which apply to all buckets (OBCs) created with the specific bucket class. These policies include: placement, namespace, caching
+        
+          There are two types of Bucket Classes:
+           - **Standard:** Data will be ingested by Multi Cloud Object Gateway, deduped, compressed and encrypted.
+           - **Namespace:** Data will be stored as is (no dedup, compression, encryption) on the namespace stores.
+        
+          **Create a new Bucket class**
+
+          1. Go to installed operators page and click on OpenShift Data Foundation,
+          2. Go to bucket class tab.
+          3. Click on **Create Bucket Class**
+          4. Follow the wizard steps to  finish creation process.
+      review:
+        instructions: |-
+          ####  To verify that you have created bucket class and backing store.
+          Is the Bucket Class in ready state?
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+      summary:
+        success: You have successfully created bucket class
+        failed: Try the steps again.
+  conclusion: Congrats, the OpenShift Data Foundation operator is ready to use.
+`

--- a/controllers/quickstarts.go
+++ b/controllers/quickstarts.go
@@ -1,0 +1,59 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/ghodss/yaml"
+	"github.com/go-logr/logr"
+	consolev1 "github.com/openshift/api/console/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func (r *StorageSystemReconciler) ensureQuickStarts(logger logr.Logger) error {
+	qscrd := extv1.CustomResourceDefinition{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "consolequickstarts.console.openshift.io", Namespace: ""}, &qscrd)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.V(2).Info("No custom resource definition found for consolequickstart. Skipping quickstart initialization")
+			return nil
+		}
+		return err
+	}
+	if len(AllQuickStarts) == 0 {
+		logger.Info("No quickstarts found")
+		return nil
+	}
+	for _, qs := range AllQuickStarts {
+		cqs := consolev1.ConsoleQuickStart{}
+		err := yaml.Unmarshal(qs, &cqs)
+		if err != nil {
+			logger.Error(err, "Failed to unmarshal ConsoleQuickStart", "ConsoleQuickStartString", string(qs))
+			continue
+		}
+		found := consolev1.ConsoleQuickStart{}
+		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: cqs.Name, Namespace: cqs.Namespace}, &found)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				err = r.Client.Create(context.TODO(), &cqs)
+				if err != nil {
+					logger.Error(err, "Failed to create quickstart", "Name", cqs.Name, "Namespace", cqs.Namespace)
+					return nil
+				}
+				logger.Info("Creating quickstarts", "Name", cqs.Name, "Namespace", cqs.Namespace)
+				continue
+			}
+			logger.Error(err, "Error has occurred when fetching quickstarts")
+			return nil
+		}
+		found.Spec = cqs.Spec
+		err = r.Client.Update(context.TODO(), &found)
+		if err != nil {
+			logger.Error(err, "Failed to update quickstart", "Name", cqs.Name, "Namespace", cqs.Namespace)
+			return nil
+		}
+		logger.Info("Updating quickstarts", "Name", cqs.Name, "Namespace", cqs.Namespace)
+	}
+	return nil
+}

--- a/controllers/quickstarts_test.go
+++ b/controllers/quickstarts_test.go
@@ -1,0 +1,100 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	consolev1 "github.com/openshift/api/console/v1"
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	cases = []struct {
+		quickstartName string
+	}{
+		{
+			quickstartName: "getting-started-odf",
+		},
+		{
+			quickstartName: "odf-configuration",
+		},
+	}
+
+	testQuickStartCRD = extv1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "consolequickstarts.console.openshift.io",
+			Namespace: "",
+		},
+	}
+)
+
+func TestQuickStartYAMLs(t *testing.T) {
+	for _, qs := range AllQuickStarts {
+		cqs := consolev1.ConsoleQuickStart{}
+		err := yaml.Unmarshal(qs, &cqs)
+		assert.NoError(t, err)
+	}
+}
+func TestEnsureQuickStarts(t *testing.T) {
+	allExpectedQuickStarts := []consolev1.ConsoleQuickStart{}
+	for _, qs := range AllQuickStarts {
+		cqs := consolev1.ConsoleQuickStart{}
+		err := yaml.Unmarshal(qs, &cqs)
+		assert.NoError(t, err)
+		allExpectedQuickStarts = append(allExpectedQuickStarts, cqs)
+	}
+
+	fakeReconciler, _ := GetFakeStorageSystemReconciler()
+	err := operatorv1alpha1.AddToScheme(fakeReconciler.Scheme)
+	assert.NoError(t, err)
+	err = fakeReconciler.Client.Create(context.TODO(), &testQuickStartCRD)
+	assert.NoError(t, err)
+	err = fakeReconciler.ensureQuickStarts(fakeReconciler.Log)
+	assert.NoError(t, err)
+	for _, c := range cases {
+		qs := consolev1.ConsoleQuickStart{}
+		err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{
+			Name: c.quickstartName,
+		}, &qs)
+		assert.NoError(t, err)
+		found := consolev1.ConsoleQuickStart{}
+		expected := consolev1.ConsoleQuickStart{}
+		for _, cqs := range allExpectedQuickStarts {
+			if qs.Name == cqs.Name {
+				found = qs
+				expected = cqs
+				break
+			}
+		}
+		assert.Equal(t, expected.Name, found.Name)
+		assert.Equal(t, expected.Namespace, found.Namespace)
+		assert.Equal(t, expected.Spec.DurationMinutes, found.Spec.DurationMinutes)
+		assert.Equal(t, expected.Spec.Introduction, found.Spec.Introduction)
+		assert.Equal(t, expected.Spec.DisplayName, found.Spec.DisplayName)
+	}
+	assert.Equal(t, len(allExpectedQuickStarts), len(getActualQuickStarts(t, cases, fakeReconciler)))
+}
+
+func getActualQuickStarts(t *testing.T, cases []struct {
+	quickstartName string
+}, reconciler *StorageSystemReconciler) []consolev1.ConsoleQuickStart {
+	allActualQuickStarts := []consolev1.ConsoleQuickStart{}
+	for _, c := range cases {
+		qs := consolev1.ConsoleQuickStart{}
+		err := reconciler.Client.Get(context.TODO(), types.NamespacedName{
+			Name: c.quickstartName,
+		}, &qs)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		assert.NoError(t, err)
+		allActualQuickStarts = append(allActualQuickStarts, qs)
+	}
+	return allActualQuickStarts
+}

--- a/controllers/storagesystem_controller.go
+++ b/controllers/storagesystem_controller.go
@@ -52,6 +52,8 @@ type StorageSystemReconciler struct {
 //+kubebuilder:rbac:groups=odf.openshift.io,resources=storagesystems/finalizers,verbs=update
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=console.openshift.io,resources=consolequickstarts,verbs=*
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -129,6 +131,11 @@ func (r *StorageSystemReconciler) reconcile(instance *odfv1alpha1.StorageSystem,
 		}
 		logger.Info("storagesystem object is terminated, skipping reconciliation")
 		return ctrl.Result{}, nil
+	}
+
+	err = r.ensureQuickStarts(logger)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	err = r.ensureSubscription(instance, logger)

--- a/controllers/storagesystem_controller_fake.go
+++ b/controllers/storagesystem_controller_fake.go
@@ -22,7 +22,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	consolev1 "github.com/openshift/api/console/v1"
 	odfv1alpha1 "github.com/red-hat-data-services/odf-operator/api/v1alpha1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func GetFakeStorageSystem() *odfv1alpha1.StorageSystem {
@@ -45,6 +47,10 @@ func GetFakeStorageSystemReconciler() (*StorageSystemReconciler, *odfv1alpha1.St
 
 	scheme := runtime.NewScheme()
 	_ = odfv1alpha1.AddToScheme(scheme)
+
+	_ = consolev1.AddToScheme(scheme)
+
+	_ = extv1.AddToScheme(scheme)
 
 	fakeStorageSystemReconciler := &StorageSystemReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(fakeStorageSystem).Build(),

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,19 @@ module github.com/red-hat-data-services/odf-operator
 go 1.15
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
+	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/custom-resource-status v1.1.0
 	github.com/operator-framework/api v0.9.2
 	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.20.2
+	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
+
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20201203102015-275406142edb // required for Quickstart CRD

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -394,6 +395,9 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/openshift/api v0.0.0-20201203102015-275406142edb h1:5LCeBL03+6NkoOvb/hna8M/BQdZK2mXJ5l7J7FfyuXg=
+github.com/openshift/api v0.0.0-20201203102015-275406142edb/go.mod h1:RDvBcRQMGLa3aNuDuejVBbTEQj/2i14NXdpOLqbNBvM=
+github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/custom-resource-status v1.1.0 h1:EjSh0f3vF6eaS3zAToVHUXcS7N2jVEosUFJ0sRKvmZ0=
 github.com/openshift/custom-resource-status v1.1.0/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
 github.com/operator-framework/api v0.9.2 h1:X9Es0eWeDd62gcrsWRgFQe4nUKdpqPdI9EpYLfPc6NU=
@@ -596,6 +600,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -654,6 +659,7 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -829,6 +835,7 @@ honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.0.0-20190725062911-6607c48751ae/go.mod h1:1O0xzX/RAtnm7l+5VEUxZ1ysO2ghatfq/OZED4zM9kA=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=
+k8s.io/api v0.19.2/go.mod h1:IQpK0zFQ1xc5iNIQPqzgoOwuFugaYHK4iCknlAQP9nI=
 k8s.io/api v0.20.1/go.mod h1:KqwcCVogGxQY3nBlRpwt+wpAMF/KjaCc7RpywacvqUo=
 k8s.io/api v0.20.2 h1:y/HR22XDZY3pniu9hIFDLpUCPq2w5eQ6aV/VFQ7uJMw=
 k8s.io/api v0.20.2/go.mod h1:d7n6Ehyzx+S+cE3VhTGfVNNqtGc/oL9DCdYYahlurV8=
@@ -837,6 +844,7 @@ k8s.io/apiextensions-apiserver v0.20.1 h1:ZrXQeslal+6zKM/HjDXLzThlz/vPSxrfK3OqL8
 k8s.io/apiextensions-apiserver v0.20.1/go.mod h1:ntnrZV+6a3dB504qwC5PN/Yg9PBiDNt1EVqbW2kORVk=
 k8s.io/apimachinery v0.0.0-20190719140911-bfcf53abc9f8/go.mod h1:sBJWIJZfxLhp7mRsRyuAE/NfKTr3kXGR1iaqg8O0gJo=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.19.2/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/apimachinery v0.20.1/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
 k8s.io/apimachinery v0.20.2 h1:hFx6Sbt1oG0n6DZ+g4bFt5f6BoMkOjKWsQFu077M3Vg=
 k8s.io/apimachinery v0.20.2/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
@@ -848,6 +856,7 @@ k8s.io/client-go v0.20.2 h1:uuf+iIAbfnCSw8IGAv/Rg0giM+2bOzHLOsbbrwrdhNQ=
 k8s.io/client-go v0.20.2/go.mod h1:kH5brqWqp7HDxUFKoEgiI4v8G1xzbe9giaCenUWJzgE=
 k8s.io/code-generator v0.0.0-20190717022600-77f3a1fe56bb/go.mod h1:cDx5jQmWH25Ff74daM7NVYty9JWw9dvIS9zT9eIubCY=
 k8s.io/code-generator v0.18.2/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
+k8s.io/code-generator v0.19.2/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
 k8s.io/code-generator v0.20.1/go.mod h1:UsqdF+VX4PU2g46NC2JRs4gc+IfrctnwHb76RNbWHJg=
 k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmDfUM=
 k8s.io/component-base v0.20.1/go.mod h1:guxkoJnNoh8LNrbtiQOlyp2Y2XFCZQmrcg2n/DeYNLk=
@@ -856,6 +865,7 @@ k8s.io/component-base v0.20.2/go.mod h1:pzFtCiwe/ASD0iV7ySMu8SYVJjCapNM9bjvk7ptp
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -868,6 +878,7 @@ k8s.io/klog/v2 v2.4.0 h1:7+X0fUguPyrKEC4WjH8iGDg3laWgMo5tMnRTIGTTxGQ=
 k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058/go.mod h1:nfDlWeOsu3pUf4yWGL+ERqohP4YsZcBJXWMK+gkzOA4=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
+k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
@@ -892,6 +903,7 @@ sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/main.go
+++ b/main.go
@@ -35,7 +35,10 @@ import (
 	odfv1alpha1 "github.com/red-hat-data-services/odf-operator/api/v1alpha1"
 	"github.com/red-hat-data-services/odf-operator/controllers"
 	subscriptionwebhook "github.com/red-hat-data-services/odf-operator/webhook/subscription"
+
 	//+kubebuilder:scaffold:imports
+	consolev1 "github.com/openshift/api/console/v1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 var (
@@ -50,6 +53,10 @@ func init() {
 
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
+
+	utilruntime.Must(consolev1.AddToScheme(scheme))
+	utilruntime.Must(extv1.AddToScheme(scheme))
+
 }
 
 func main() {


### PR DESCRIPTION
For 4.9 release, OCS operator will be replaced with the ODF at a higher level. Hence we would want to make sure that new quickstarts accurately represent the workflows for ODF operator.

This commit includes all the relevant changes that are applicable to newer UI that is coming as part of OCP 4.9
    
 **What is a QuickStart ?**
Quick starts walk users through completing different tasks in the console. In OpenShift 4.7, we added a quick start custom resource. This allows operators and administrators to contribute new quick starts to the cluster beyond the out-of-the-box set. Typically, quick starts for operators are created by the operator itself after the operator is installed.
    
**What does this PR add ?**
This commit adds ensureQuickStarts and relevant dependencies to initialize the new QuickStarts (ODF-Configuration, Getting Started with ODF).
    
Links
README: https://github.com/openshift/console-operator/tree/master/quickstarts
GUIDELINES: http://openshift.github.io/openshift-origin-design/conventions/documentation/quick-starts.html