### PR TITLE
action: Add commitlint action for checking commits

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,27 @@
+name: commitlint
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: run commitlint
+      uses: wagoid/commitlint-github-action@v3
+      with:
+        configFile: './.github/workflows/conf/commitlintrc.json'
+        helpURL: |
+          Some helpful links
+          Contribution Guide -> https://github.com/red-hat-data-services/odf-operator/blob/main/CONTRIBUTING.md#commit-structure
+          Naming Conventions -> https://commitlint.js.org/#/concepts-commit-conventions
+          Rules -> https://commitlint.js.org/#/reference-rules
+          How to Write a Good Git Commit Message -> https://chris.beams.io/posts/git-commit

--- a/.github/workflows/conf/commitlintrc.json
+++ b/.github/workflows/conf/commitlintrc.json
@@ -1,0 +1,85 @@
+{
+    "extends": [
+        "@commitlint/config-conventional"
+    ],
+    "rules": {
+        "body-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "body-empty": [
+            1,
+            "never"
+        ],
+        "body-full-stop": [
+            1,
+            "always",
+            "."
+        ],
+        "body-leading-blank": [
+            2,
+            "always"
+        ],
+        "body-max-line-length": [
+            2,
+            "always",
+            72
+        ],
+        "footer-leading-blank": [
+            2,
+            "always"
+        ],
+        "header-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "header-full-stop": [
+            2,
+            "never",
+            "."
+        ],
+        "header-max-length": [
+            2,
+            "always",
+            72
+        ],
+        "signed-off-by": [
+            2,
+            "always"
+        ],
+        "subject-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "subject-empty": [
+            2,
+            "never"
+        ],
+        "type-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "type-empty": [
+            2,
+            "never"
+        ],
+        "type-enum": [
+            2,
+            "always",
+            [
+                "action",
+                "api",
+                "bundle",
+                "ci",
+                "controllers",
+                "docs",
+                "godeps",
+                "test"
+            ]
+        ]
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# How to Contribute
+
+## Commit structure
+
+ODF maintainers value clear and explanatory commit messages. So by default each of your commits must follow below rules:
+
+### We follow the common commit conventions
+```
+type: subject
+
+body?
+
+footer?
+```
+
+### Here is an example of an acceptable commit message for a bug fix:
+```
+component: commit title
+
+This is the commit message, here I'm explaining, what the bug was along
+with its root cause.
+Then I'm explaining how I fixed it.
+
+Fix: https://bugzilla.redhat.com/show_bug.cgi?id=<NUMBER>
+
+Signed-off-by: First_Name Last_Name <email address>
+```
+
+### Here is an example of an acceptable commit message for a new feature:
+```
+component: commit title
+
+This is the commit message, here I'm explaining, what this feature is
+and why do we need it.
+
+Signed-off-by: First_Name Last_Name <email address>
+```
+
+### type/component must be one of the following according to files you are changing:
+```yaml
+action
+api
+ci
+controllers
+docs
+godeps
+makefile
+test
+```
+
+Note: sometimes you will feel like there is not so much to say, for instance if you are fixing a typo in a text. In that case, it is acceptable to shorten the commit message.
+
+### More Guidelines:
+- Type/component should not be empty.
+- Your commit msg should not exceed more than 72 characters per line.
+- Header should not have a full stop.
+- Body should always end with the full stop.
+- There should be one blank line in b/w header and body.
+- There should be one blank line in b/w body and footer.
+- Your commit message must be signed-off.


### PR DESCRIPTION
commitlint will force a developer to write a commit as per our guidelines

reference links:
Naming Conventions -> https://commitlint.js.org/#/concepts-commit-conventions                                                                                                   
Rules -> https://commitlint.js.org/#/reference-rules

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>